### PR TITLE
Remove when check for the spec having the upload_wait & add ignore_errors

### DIFF
--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -50,7 +50,7 @@
     collect_upload_wait: "{{ cost_mgmt_setup.resources[0].spec.upload_wait | int }}"
   when:
     - cost_mgmt_setup.resources
-    - cost_mgmt_setup.resources[0].spec.upload_wait
+  ignore_errors: true
 
 - name: Obtain metering api info
   k8s_info:

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -48,8 +48,7 @@
 - name: Set upload_wait
   set_fact:
     collect_upload_wait: "{{ cost_mgmt_setup.resources[0].spec.upload_wait | int }}"
-  when:
-    - cost_mgmt_setup.resources
+  when: cost_mgmt_setup.resources
   ignore_errors: true
 
 - name: Obtain metering api info


### PR DESCRIPTION
Checking the spec for upload_wait when it doesn't exist causes the task to Fail and since there is not an ignore_errors clause, the collect role will not continue. (Remove the when check & add an ignore_errors clause) 