### PR TITLE
Add ability to capture logs from operator on molecule failure.

### DIFF
--- a/molecule/test-cluster/converge.yml
+++ b/molecule/test-cluster/converge.yml
@@ -71,6 +71,6 @@
         - "'Successful' in (cm_data_cr |
           json_query('resources[].status.conditions[].reason'))"
       delay: 12
-      retries: 25
+      retries: 10
 
 - import_playbook: '{{ playbook_dir }}/../default/asserts.yml'

--- a/molecule/test-local/converge.yml
+++ b/molecule/test-local/converge.yml
@@ -159,7 +159,7 @@
             - "'Metering has not been configured.' in
               (cr | json_query('resources[].status.conditions[].message'))"
           delay: 12
-          retries: 25
+          retries: 10
 
       rescue:
         - name: debug cr
@@ -184,15 +184,28 @@
             deploy: '{{ lookup("k8s",
               kind="Deployment",
               api_version="apps/v1",
-              namespace=namespace,
-              label_selector="app=cost-mgmt"
+              namespace=namespace
             )}}'
 
         - name: get operator logs
           ignore_errors: yes
           failed_when: false
           command: kubectl logs
-            deployment/{{ definition.metadata.name }} -n {{ namespace }}
+            deployment/{{ definition.metadata.name }} -n {{ namespace }} -c operator
+          environment:
+            KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+          vars:
+            definition: "{{ lookup('template',
+              '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+          register: log
+
+        - debug: var=log.stdout_lines
+
+        - name: get ansible logs
+          ignore_errors: yes
+          failed_when: false
+          command: kubectl logs
+            deployment/{{ definition.metadata.name }} -n {{ namespace }} -c ansible
           environment:
             KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
           vars:
@@ -348,15 +361,28 @@
             deploy: '{{ lookup("k8s",
               kind="Deployment",
               api_version="apps/v1",
-              namespace=namespace,
-              label_selector="app=cost-mgmt"
+              namespace=namespace
             )}}'
 
         - name: get operator logs
           ignore_errors: yes
           failed_when: false
           command: kubectl logs
-            deployment/{{ definition.metadata.name }} -n {{ namespace }}
+            deployment/{{ definition.metadata.name }} -n {{ namespace }} -c operator
+          environment:
+            KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+          vars:
+            definition: "{{ lookup('template',
+              '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+          register: log
+
+        - debug: var=log.stdout_lines
+
+        - name: get ansible logs
+          ignore_errors: yes
+          failed_when: false
+          command: kubectl logs
+            deployment/{{ definition.metadata.name }} -n {{ namespace }} -c ansible
           environment:
             KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
           vars:
@@ -478,7 +504,7 @@
             - "'Successful' in (cm_data_cr |
               json_query('resources[].status.conditions[].reason'))"
           delay: 12
-          retries: 25
+          retries: 10
 
       rescue:
         - name: debug cr
@@ -503,15 +529,28 @@
             deploy: '{{ lookup("k8s",
               kind="Deployment",
               api_version="apps/v1",
-              namespace=namespace,
-              label_selector="app=cost-mgmt"
+              namespace=namespace
             )}}'
 
         - name: get operator logs
           ignore_errors: yes
           failed_when: false
           command: kubectl logs
-            deployment/{{ definition.metadata.name }} -n {{ namespace }}
+            deployment/{{ definition.metadata.name }} -n {{ namespace }} -c  operator
+          environment:
+            KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+          vars:
+            definition: "{{ lookup('template',
+              '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+          register: log
+
+        - debug: var=log.stdout_lines
+
+        - name: get ansible logs
+          ignore_errors: yes
+          failed_when: false
+          command: kubectl logs
+            deployment/{{ definition.metadata.name }} -n {{ namespace }} -c  ansible
           environment:
             KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
           vars:


### PR DESCRIPTION
* Gather logs with the -c container flag in kubectl logs
* Gather both operator and ansible logs

Example of what the triggered failure looks like and the logs that are captured:
```
    TASK [Wait 2m for reconciliation to fail due to openshift metering not being configured] ***
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (10 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (9 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (8 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (7 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (6 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (5 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (4 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (3 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (2 retries left).
    FAILED - RETRYING: Wait 2m for reconciliation to fail due to openshift metering not being configured (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 10, "changed": false, "resources": [{"apiVersion": "cost-mgmt.openshift.io/v1alpha1", "kind": "CostManagement", "metadata": {"creationTimestamp": "2020-04-02T23:16:21Z", "generation": 1, "name": "cost-mgmt-setup", "namespace": "openshift-metering", "resourceVersion": "999", "selfLink": "/apis/cost-mgmt.openshift.io/v1alpha1/namespaces/openshift-metering/costmanagements/cost-mgmt-setup", "uid": "18dbb572-ff6a-4507-9567-402cb6ab7176"}, "spec": {"authentication": "basic", "authentication_secret_name": "auth-secret-name-placeholder", "clusterID": "cluster-id-placeholder", "ingress_url": "http://localhost:8000", "reporting_operator_token_name": "reporting-operator-token-placeholder", "upload_wait": 1, "validate_cert": "false"}}]}
    
    TASK [debug cr] ****************************************************************
    ok: [localhost] => {
        "debug_cr": {
            "apiVersion": "cost-mgmt.openshift.io/v1alpha1",
            "kind": "CostManagement",
            "metadata": {
                "creationTimestamp": "2020-04-02T23:16:21Z",
                "generation": 1,
                "name": "cost-mgmt-setup",
                "namespace": "openshift-metering",
                "resourceVersion": "999",
                "selfLink": "/apis/cost-mgmt.openshift.io/v1alpha1/namespaces/openshift-metering/costmanagements/cost-mgmt-setup",
                "uid": "18dbb572-ff6a-4507-9567-402cb6ab7176"
            },
            "spec": {
                "authentication": "basic",
                "authentication_secret_name": "auth-secret-name-placeholder",
                "clusterID": "cluster-id-placeholder",
                "ingress_url": "http://localhost:8000",
                "reporting_operator_token_name": "reporting-operator-token-placeholder",
                "upload_wait": 1,
                "validate_cert": "false"
            }
        },
        "failed_when_result": false
    }
    
    TASK [debug cost-mgmt lookup] **************************************************
/Users/christopherhambridge/.local/share/virtualenvs/korekuta-operator-AdfofK8p/lib/python3.6/site-packages/kubernetes/config/kube_config.py:509: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config_dict=yaml.load(f),
    ok: [localhost] => {
        "deploy": {
            "metadata": {
                "annotations": {
                    "deployment.kubernetes.io/revision": "1"
                },
                "creationTimestamp": "2020-04-02T23:16:15Z",
                "generation": 1,
                "name": "cost-mgmt-operator",
                "namespace": "openshift-metering",
                "resourceVersion": "1166",
                "selfLink": "/apis/apps/v1/namespaces/openshift-metering/deployments/cost-mgmt-operator",
                "uid": "356e2bba-0824-456c-9615-a112d1ed9c3f"
            },
            "spec": {
                "progressDeadlineSeconds": 600,
                "replicas": 1,
                "revisionHistoryLimit": 10,
                "selector": {
                    "matchLabels": {
                        "name": "cost-mgmt-operator"
                    }
                },
                "strategy": {
                    "rollingUpdate": {
                        "maxSurge": "25%",
                        "maxUnavailable": "25%"
                    },
                    "type": "RollingUpdate"
                },
                "template": {
                    "metadata": {
                        "creationTimestamp": null,
                        "labels": {
                            "app": "cost-mgmt",
                            "name": "cost-mgmt-operator"
                        }
                    },
                    "spec": {
                        "containers": [
                            {
                                "command": [
                                    "/usr/local/bin/ao-logs",
                                    "/tmp/ansible-operator/runner",
                                    "stdout"
                                ],
                                "image": "cost-mgmt.openshift.io/cost-mgmt-operator:testing",
                                "imagePullPolicy": "Never",
                                "name": "ansible",
                                "resources": {},
                                "terminationMessagePath": "/dev/termination-log",
                                "terminationMessagePolicy": "File",
                                "volumeMounts": [
                                    {
                                        "mountPath": "/tmp/ansible-operator/runner",
                                        "name": "runner",
                                        "readOnly": true
                                    },
                                    {
                                        "mountPath": "/tmp/cost-mgmt-operator-collect",
                                        "name": "cost-mgmt-operator"
                                    }
                                ]
                            },
                            {
                                "env": [
                                    {
                                        "name": "WATCH_NAMESPACE",
                                        "valueFrom": {
                                            "fieldRef": {
                                                "apiVersion": "v1",
                                                "fieldPath": "metadata.namespace"
                                            }
                                        }
                                    },
                                    {
                                        "name": "POD_NAME",
                                        "valueFrom": {
                                            "fieldRef": {
                                                "apiVersion": "v1",
                                                "fieldPath": "metadata.name"
                                            }
                                        }
                                    },
                                    {
                                        "name": "OPERATOR_NAME",
                                        "value": "cost-mgmt-operator"
                                    },
                                    {
                                        "name": "ANSIBLE_GATHERING",
                                        "value": "explicit"
                                    }
                                ],
                                "image": "cost-mgmt.openshift.io/cost-mgmt-operator:testing",
                                "imagePullPolicy": "Never",
                                "name": "operator",
                                "resources": {},
                                "terminationMessagePath": "/dev/termination-log",
                                "terminationMessagePolicy": "File",
                                "volumeMounts": [
                                    {
                                        "mountPath": "/tmp/ansible-operator/runner",
                                        "name": "runner"
                                    },
                                    {
                                        "mountPath": "/tmp/cost-mgmt-operator-collect",
                                        "name": "cost-mgmt-operator"
                                    },
                                    {
                                        "mountPath": "/var/run/configmaps/trusted-ca-bundle",
                                        "name": "trusted-ca-volume",
                                        "readOnly": true
                                    }
                                ]
                            }
                        ],
                        "dnsPolicy": "ClusterFirst",
                        "restartPolicy": "Always",
                        "schedulerName": "default-scheduler",
                        "securityContext": {},
                        "serviceAccount": "cost-mgmt-operator",
                        "serviceAccountName": "cost-mgmt-operator",
                        "terminationGracePeriodSeconds": 30,
                        "volumes": [
                            {
                                "emptyDir": {},
                                "name": "runner"
                            },
                            {
                                "emptyDir": {},
                                "name": "cost-mgmt-operator"
                            },
                            {
                                "configMap": {
                                    "defaultMode": 420,
                                    "name": "trusted-ca-bundle"
                                },
                                "name": "trusted-ca-volume"
                            }
                        ]
                    }
                }
            },
            "status": {
                "conditions": [
                    {
                        "lastTransitionTime": "2020-04-02T23:16:15Z",
                        "lastUpdateTime": "2020-04-02T23:16:21Z",
                        "message": "ReplicaSet \"cost-mgmt-operator-75484c4986\" has successfully progressed.",
                        "reason": "NewReplicaSetAvailable",
                        "status": "True",
                        "type": "Progressing"
                    },
                    {
                        "lastTransitionTime": "2020-04-02T23:18:08Z",
                        "lastUpdateTime": "2020-04-02T23:18:08Z",
                        "message": "Deployment does not have minimum availability.",
                        "reason": "MinimumReplicasUnavailable",
                        "status": "False",
                        "type": "Available"
                    }
                ],
                "observedGeneration": 1,
                "replicas": 1,
                "unavailableReplicas": 1,
                "updatedReplicas": 1
            }
        },
        "failed_when_result": false
    }
    
    TASK [get operator logs] *******************************************************
/Users/christopherhambridge/.local/share/virtualenvs/korekuta-operator-AdfofK8p/lib/python3.6/site-packages/kubernetes/config/kube_config.py:509: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config_dict=yaml.load(f),
    changed: [localhost]
    
    TASK [debug] *******************************************************************
    ok: [localhost] => {
        "log.stdout_lines": [
            "Adding user ansible-operator with current UID 1000580000 to /etc/passwd",
            "{\"level\":\"info\",\"ts\":1585869457.5191238,\"logger\":\"cmd\",\"msg\":\"Go Version: go1.13.8\"}",
            "{\"level\":\"info\",\"ts\":1585869457.5191953,\"logger\":\"cmd\",\"msg\":\"Go OS/Arch: linux/amd64\"}",
            "{\"level\":\"info\",\"ts\":1585869457.5192304,\"logger\":\"cmd\",\"msg\":\"Version of operator-sdk: v0.15.2\"}",
            "{\"level\":\"info\",\"ts\":1585869457.5192642,\"logger\":\"cmd\",\"msg\":\"Watching namespace.\",\"Namespace\":\"openshift-metering\"}",
            "{\"level\":\"error\",\"ts\":1585869487.4859884,\"logger\":\"controller-runtime.manager\",\"msg\":\"Failed to get API Group-Resources\",\"error\":\"Get https://10.96.0.1:443/api?timeout=32s: dial tcp 10.96.0.1:443: i/o timeout\",\"stacktrace\":\"github.com/go-logr/zapr.(*zapLogger).Error\\n\\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\\nsigs.k8s.io/controller-runtime/pkg/manager.New\\n\\tpkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/manager/manager.go:238\\ngithub.com/operator-framework/operator-sdk/pkg/ansible.Run\\n\\tsrc/github.com/operator-framework/operator-sdk/pkg/ansible/run.go:82\\ngithub.com/operator-framework/operator-sdk/cmd/operator-sdk/execentrypoint.newRunAnsibleCmd.func1\\n\\tsrc/github.com/operator-framework/operator-sdk/cmd/operator-sdk/execentrypoint/ansible.go:38\\ngithub.com/spf13/cobra.(*Command).execute\\n\\tpkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826\\ngithub.com/spf13/cobra.(*Command).ExecuteC\\n\\tpkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914\\ngithub.com/spf13/cobra.(*Command).Execute\\n\\tpkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864\\nmain.main\\n\\tsrc/github.com/operator-framework/operator-sdk/cmd/operator-sdk/main.go:39\\nruntime.main\\n\\t/home/travis/.gimme/versions/go1.13.8.linux.amd64/src/runtime/proc.go:203\"}",
            "{\"level\":\"error\",\"ts\":1585869487.4869351,\"logger\":\"cmd\",\"msg\":\"Failed to create a new manager.\",\"Namespace\":\"openshift-metering\",\"error\":\"Get https://10.96.0.1:443/api?timeout=32s: dial tcp 10.96.0.1:443: i/o timeout\",\"stacktrace\":\"github.com/go-logr/zapr.(*zapLogger).Error\\n\\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\\ngithub.com/operator-framework/operator-sdk/pkg/ansible.Run\\n\\tsrc/github.com/operator-framework/operator-sdk/pkg/ansible/run.go:98\\ngithub.com/operator-framework/operator-sdk/cmd/operator-sdk/execentrypoint.newRunAnsibleCmd.func1\\n\\tsrc/github.com/operator-framework/operator-sdk/cmd/operator-sdk/execentrypoint/ansible.go:38\\ngithub.com/spf13/cobra.(*Command).execute\\n\\tpkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826\\ngithub.com/spf13/cobra.(*Command).ExecuteC\\n\\tpkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914\\ngithub.com/spf13/cobra.(*Command).Execute\\n\\tpkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864\\nmain.main\\n\\tsrc/github.com/operator-framework/operator-sdk/cmd/operator-sdk/main.go:39\\nruntime.main\\n\\t/home/travis/.gimme/versions/go1.13.8.linux.amd64/src/runtime/proc.go:203\"}",
            "Error: Get https://10.96.0.1:443/api?timeout=32s: dial tcp 10.96.0.1:443: i/o timeout",
            "Usage:",
            "  operator-sdk exec-entrypoint ansible [flags]",
            "",
            "Flags:",
            "      --ansible-verbosity int            Ansible verbosity. Overridden by environment variable. (default 2)",
            "  -h, --help                             help for ansible",
            "      --inject-owner-ref                 The ansible operator will inject owner references unless this flag is false (default true)",
            "      --max-workers int                  Maximum number of workers to use. Overridden by environment variable. (default 1)",
            "      --reconcile-period duration        Default reconcile period for controllers (default 1m0s)",
            "      --watches-file string              Path to the watches file to use (default \"./watches.yaml\")",
            "      --zap-devel                        Enable zap development mode (changes defaults to console encoder, debug log level, and disables sampling)",
            "      --zap-encoder encoder              Zap log encoding ('json' or 'console')",
            "      --zap-level level                  Zap log level (one of 'debug', 'info', 'error' or any integer value > 0) (default info)",
            "      --zap-sample sample                Enable zap log sampling. Sampling will be disabled for integer log levels > 1",
            "      --zap-time-encoding timeEncoding   Sets the zap time format ('epoch', 'millis', 'nano', or 'iso8601') (default )",
            "",
            "Global Flags:",
            "      --verbose   Enable verbose logging"
        ]
    }
    
    TASK [get ansible logs] ********************************************************
    changed: [localhost]
    
    TASK [debug] *******************************************************************
    ok: [localhost] => {
        "log.stdout_lines": [
            "Setting up watches.  Beware: since -r was given, this may take a while!",
            "Watches established."
        ]
    }
    
    TASK [fail] ********************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed on action: converge"}
```

Full failure run: 
[molecule-capture-failure.txt](https://github.com/project-koku/korekuta-operator/files/4424274/molecule-capture-failure.txt)
