### PR TITLE
add DCO, update CONTRIBUTING to reference DCO

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,0 +1,7 @@
+Certificate of Origin
+=====================
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the `DCO <DCO>` file for details.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright Red Hat, Inc. and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
This adds a Developer Certificate of Origin document and updates our CONTRIBUTING doc to reference the DCO.

The proposed contributing workflow follows the pattern established by CoreOS, where all contributions implicitly agree to the DCO. An alternative approach would be to follow the pattern established by the Linux Kernel, which requires sign-offs (using git commit -s) for every commit.

I believe the CoreOS approach is preferable.