### PR TITLE
Fix hourly reports so runImmediately doesn't cause execution of future datetimes.

### DIFF
--- a/roles/setup/tasks/reports.yml
+++ b/roles/setup/tasks/reports.yml
@@ -53,25 +53,6 @@
   when:
     - (evaluate_month | int)  < 10
 
-# Logic to set report_start_month
-
-- name: Set report_start_month to previous month if not January
-  set_fact:
-    report_start_month: '{{ ((evaluate_month | int) - 1) | string }}'
-  when:
-    - (evaluate_month | int) > 1
-
-- name: Set report_start_month to 12 (December) if January
-  set_fact:
-    report_start_month: '12'
-  when: (evaluate_month | int) == 1
-
-- name: Set report_start_month if single digit
-  set_fact:
-    report_start_month: '{{ "0" + report_start_month }}'
-  when:
-    - (report_start_month | int) < 10
-
 # Logic to set report_end_month
 
 - name: Set report_end_month to next month if not December
@@ -110,19 +91,6 @@
   when:
     - (month_delta | int) < 0
     - (evaluate_month | int) == 12
-
-# Logic to set report_start_year
-
-- name: Set report_start_year to evaluate year if Feb-Dec
-  set_fact:
-    report_start_year: '{{ evaluate_year | string }}'
-  when: (evaluate_month | int) > 1
-
-- name: Set report_start_year to previous year if January
-  set_fact:
-    report_start_year: '{{ ((evaluate_year | int) - 1) | string }}'
-  when:
-    - (evaluate_month | int) == 1
 
 # Logic to set report_end_year
 

--- a/roles/setup/templates/cm_openshift_node_labels_lookback_scheduled_report.j2
+++ b/roles/setup/templates/cm_openshift_node_labels_lookback_scheduled_report.j2
@@ -10,8 +10,6 @@ spec:
   inputs:
     - name: CostManagementOpenShiftNodeLabelsReportName
       value: cm-openshift-node-labels-{{ current_year_month }}
-  runImmediately: true
-  reportingStart: '{{ report_start_year }}-{{ report_start_month }}-26T00:00:00Z'
   reportingEnd: '{{ report_end_year }}-{{ report_end_month }}-02T00:00:00Z'
   schedule:
     period: hourly

--- a/roles/setup/templates/cm_openshift_node_labels_scheduled_report.j2
+++ b/roles/setup/templates/cm_openshift_node_labels_scheduled_report.j2
@@ -7,8 +7,6 @@ metadata:
   name: cm-openshift-node-labels-{{ current_year_month }}
 spec:
   query: cm-openshift-node-labels
-  reportingStart: '{{ report_start_year }}-{{ report_start_month }}-26T00:00:00Z'
   reportingEnd: '{{ report_end_year }}-{{ report_end_month }}-02T00:00:00Z'
-  runImmediately: true
   schedule:
     period: hourly

--- a/roles/setup/templates/cm_openshift_persistentvolumeclaim_lookback_scheduled_report.j2
+++ b/roles/setup/templates/cm_openshift_persistentvolumeclaim_lookback_scheduled_report.j2
@@ -10,8 +10,6 @@ spec:
   inputs:
     - name: PersistentVolumeClaimUsageReportName
       value: cm-openshift-persistentvolumeclaim-{{ current_year_month }}
-  runImmediately: true
-  reportingStart: '{{ report_start_year }}-{{ report_start_month }}-26T00:00:00Z'
   reportingEnd: '{{ report_end_year }}-{{ report_end_month }}-02T00:00:00Z'
   schedule:
     period: hourly

--- a/roles/setup/templates/cm_openshift_persistentvolumeclaim_scheduled_report.j2
+++ b/roles/setup/templates/cm_openshift_persistentvolumeclaim_scheduled_report.j2
@@ -7,8 +7,6 @@ metadata:
   name: cm-openshift-persistentvolumeclaim-{{ current_year_month }}
 spec:
   query: cm-openshift-persistentvolumeclaim
-  reportingStart: '{{ report_start_year }}-{{ report_start_month }}-26T00:00:00Z'
   reportingEnd: '{{ report_end_year }}-{{ report_end_month }}-02T00:00:00Z'
-  runImmediately: true
   schedule:
     period: hourly

--- a/roles/setup/templates/cm_openshift_usage_lookback_scheduled_report.j2
+++ b/roles/setup/templates/cm_openshift_usage_lookback_scheduled_report.j2
@@ -10,8 +10,6 @@ spec:
   inputs:
     - name: CostManagementOpenShiftUsageReportName
       value: cm-openshift-usage-{{ current_year_month }}
-  runImmediately: true
-  reportingStart: '{{ report_start_year }}-{{ report_start_month }}-26T00:00:00Z'
   reportingEnd: '{{ report_end_year }}-{{ report_end_month }}-02T00:00:00Z'
   schedule:
     period: hourly

--- a/roles/setup/templates/cm_openshift_usage_scheduled_report.j2
+++ b/roles/setup/templates/cm_openshift_usage_scheduled_report.j2
@@ -7,8 +7,6 @@ metadata:
   name: cm-openshift-usage-{{ current_year_month }}
 spec:
   query: cm-openshift-usage
-  reportingStart: '{{ report_start_year }}-{{ report_start_month }}-26T00:00:00Z'
   reportingEnd: '{{ report_end_year }}-{{ report_end_month }}-02T00:00:00Z'
-  runImmediately: true
   schedule:
     period: hourly


### PR DESCRIPTION


* remove `runImmediately:true`
* remove `reportingStart` which essentially defaults it to creation time of the report
* remove  tasks to generate `report_start_year` and `report_start_month`

Note: Since we are controlling when we create each months report the reportStart time is roughly the same time