### PR TITLE
Fix report structure

### DIFF
--- a/roles/collect/files/package_report.py
+++ b/roles/collect/files/package_report.py
@@ -26,7 +26,6 @@ import os
 import sys
 import tarfile
 from datetime import datetime
-from uuid import uuid4
 
 
 DEFAULT_MAX_SIZE = 100
@@ -35,7 +34,7 @@ MEGABYTE = 1024 * 1024
 TEMPLATE = {
     "files": None,
     "date": datetime.utcnow().isoformat(),
-    "uuid": str(uuid4()),
+    "uuid": None,
     "cluster_id": None
 }
 
@@ -83,6 +82,7 @@ def parse_args():
                         help="OCP Cluster ID")
     parser.add_argument("-v", "--verbosity", action="count",
                         default=0, help="increase verbosity (up to -vvv)")
+    parser.add_argument("--manifest-id", required=True, help="Manifest UUID")
     return parser.parse_args()
 
 
@@ -191,6 +191,7 @@ def render_manifest(args):
     manifest = TEMPLATE
     manifest["cluster_id"] = args.ocp_cluster_id
     manifest["files"] = os.listdir(args.filepath)
+    manifest["uuid"] = args.manifest_id
     LOG.debug(f"rendered manifest: {manifest}")
     manifest_filename = f"{args.filepath}/manifest.json"
 

--- a/roles/collect/files/package_report.py
+++ b/roles/collect/files/package_report.py
@@ -225,7 +225,7 @@ def write_tarball(tarfilename, archivefiles=[]):
         with tarfile.open(tarfilename, f"{FILE_FLAG}:gz") as tarball:
             for fname in archivefiles:
                 LOG.debug(f"Adding {fname} to {tarfilename}: ")
-                tarball.add(fname)
+                tarball.add(fname, arcname=os.path.sep)
     except FileExistsError as exc:
         LOG.critical(exc)
         sys.exit(2)

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -320,7 +320,7 @@
     - '{{ csv_stat_result.results }}'
 
 - name: Run packaging script to prepare reports for sending to Insights
-  script: package_report.py --filepath {{ ocp_cluster_id }} --max-size {{ collect_max_csvfile_size }} --ocp-cluster-id {{ ocp_cluster_id }} --overwrite
+  script: package_report.py --filepath {{ ocp_cluster_id }} --max-size {{ collect_max_csvfile_size }} --ocp-cluster-id {{ ocp_cluster_id }} --overwrite --manifest-id {{ collect_file_prefix }}
   args:
     chdir: '{{ collect_download_path }}'
   register: packaged_reports


### PR DESCRIPTION
This flattens the report structure and makes the manifest_uuid match the file_prefix so that koku will process the report files 