### PR TITLE
Fix broken link to the Ansible operator user guide 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You must have access to an OpenShift v.4.3.0+ cluster..
 
 ## Development
 
-This project was generated using Operator SDK. For a more in depth understanding of the structure of this repo, see the [user guide](https://github.com/operator-framework/operator-sdk/blob/master/doc/ansible/user-guide.md) that was used to generate it.
+This project was generated using Operator SDK. For a more in depth understanding of the structure of this repo, see the [user guide](https://sdk.operatorframework.io/docs/ansible/quickstart/) that was used to generate it.
 
 This project requires Python 3.6 or greater and Go 1.13 or greater if you plan on running the operator locally. To get started developing against `korekuta-operator` first clone a local copy of the git repository.
 


### PR DESCRIPTION
It looks like the user guide was updated & moved to https://sdk.operatorframework.io/docs/ansible/quickstart/. This PR updates our README accordingly